### PR TITLE
Bug fix: load ml_endpoint from configuration file

### DIFF
--- a/templates/prediction/prediction-api.yaml
+++ b/templates/prediction/prediction-api.yaml
@@ -47,6 +47,10 @@ Parameters:
       This string can include numbers, lowercase letters, uppercase letters, and hyphens (-).
       It cannot start or end with a hyphen (-).
     Type: String
+  WorkingBucket:
+    Description: >-
+      S3 bucket name to save intermediate configuration.
+    Type: String
   WithWeather:
     Description: >-
       Enables or disables the use of weather data.
@@ -236,6 +240,9 @@ Resources:
             ApiId: !Ref HttpApi
             Method: GET
             Path: /forecast/{meter_id}
+      Environment:
+        Variables:
+          WORKING_BUCKET: !Ref WorkingBucket
 
   #
   # Dependency Layer

--- a/templates/workload.template.yaml
+++ b/templates/workload.template.yaml
@@ -147,6 +147,7 @@ Resources:
           QSS3BucketName: !Ref QSS3BucketName
           QSS3KeyPrefix: !Ref QSS3KeyPrefix
           AthenaQueryBucket: !GetAtt PredictionStack.Outputs.AthenaQueryBucket
+          WorkingBucket: !GetAtt PredictionStack.Outputs.WorkingBucket
           WithWeather: !Ref WithWeather
           DBName: !Ref DBName
           RedshiftSecret: !GetAtt RedshiftStack.Outputs.RedshiftSecret


### PR DESCRIPTION
Using the JSON configuration file on S3 to obtain ML endpoint name instead of having it as an invocation parameter

*Issue #, if available:*
https://app.asana.com/0/1196623096559107/1196623096559133
*Description of changes:*
- Using the JSON configuration file on S3 to obtain ML endpoint name instead of having it as an invocation parameter

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
