### PR TITLE
update demo data link, add new supported regions to documentation

### DIFF
--- a/docs/partner_editable/additional_info.adoc
+++ b/docs/partner_editable/additional_info.adoc
@@ -14,6 +14,9 @@ Download the sample dataset from https://data.london.gov.uk/dataset/smartmeter-e
 
 https://data.london.gov.uk/download/smartmeter-energy-use-data-in-london-households/3527bf39-d93e-4071-8451-df2ade1ea4f2/Power-Networks-LCL-June2015(withAcornGps).zip[Download sample meter data^]
 
+
+Mirror: https://www.kaggle.com/jeanmidev/smart-meters-in-london?select=halfhourly_dataset.zip[Donwlod from kaggle]
+
 === Upload the dataset to the landing-zone (raw-data) S3 bucket
 You must upload the sample dataset to the landing-zone (raw-data) S3 bucket. The landing zone is the starting point for the AWS Glue workflow. Files that are placed in this S3 bucket are processed by the ETL pipeline. Furthermore, the AWS Glue ETL workflow tracks which files have been processed and which have not.
 

--- a/docs/partner_editable/additional_info.adoc
+++ b/docs/partner_editable/additional_info.adoc
@@ -50,7 +50,7 @@ WARNING: Make sure that your landing-zone S3 bucket contains only meter-data fil
 === (Optional) Prepare weather data for use in training and forecasting
 
 . https://www.kaggle.com/jeanmidev/smart-meters-in-london?select=weather_hourly_darksky.csv[Download^] the sample weather dataset.
-. Upload the dataset to the S3 bucket.
+. Upload the dataset to a new S3 bucket (the bucket can have any name and needs to be referenced in the following SQL statement).
 . Create a weather table in the target AWS Glue database using the following SQL statement. Replace <weather-data-location> with the location where you upload the weather dataset.
 +
 [#create_weather_table]
@@ -75,7 +75,7 @@ CREATE EXTERNAL TABLE weather(
 ROW FORMAT DELIMITED
       FIELDS TERMINATED BY ','
 LOCATION
-  's3://<weather-data-location>'
+  's3://<weather-data-location>/'
 TBLPROPERTIES (
   'has_encrypted_data'='false',
   'skip.header.line.count'='1');

--- a/docs/partner_editable/regions.adoc
+++ b/docs/partner_editable/regions.adoc
@@ -4,5 +4,7 @@ This Quick Start supports the following Regions:
 * us-east-2, US East (Ohio)
 * us-west-2, US West (Oregon)
 * eu-central-1, Europe (Frankfurt)
+* eu-west-1, Europe (Ireland)
+* eu-west-2, Europe (London)
 * ca-central-1, Canada (Central)
 * ap-south-1, Asia Pacific (Mumbai)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- added an additional link for London meter data, original link is (temp) offline. The new link points to the data set on kaggle
- added two new supported regions to the documentation (Ireland and London)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
