### PR TITLE
remove regions from taskcat that are not fully supported by cfn-nag

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -10,9 +10,7 @@ project:
     - us-east-1
     - us-east-2
     - us-west-2
-    - eu-central-1
-    - ca-central-1
-    - ap-south-1
+    - eu-west-1
 
 tests:
   full-test-all-regions:

--- a/templates/prediction/ml-pipeline-config.yaml
+++ b/templates/prediction/ml-pipeline-config.yaml
@@ -75,7 +75,6 @@ Resources:
                     sagemaker.delete_endpoint(EndpointName=endpoint_name)
                   except Exception as e:
                       logging.error('Exception: %s' % e, exc_info=True)
-                      status = cfnresponse.FAILED
                   finally:
                       cfnresponse.send(event, context, status, {}, None)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
remove regions from taskcat that are not fully supported by cfn-nag. In some regions NotebookInstanceLifecycleConfig is not known by cfn-lint although they are available in the region itself. 

Searching the cfn-lint config folder, shows that the needed artifact is only configured for the following regions:

> egrep -i 'aws::sagemaker::notebookinstancelifecycleconfig"' -R * -l
CloudSpecs/us-west-2.json
CloudSpecs/eu-west-1.json
CloudSpecs/us-east-1.json
CloudSpecs/ap-northeast-1.json
CloudSpecs/us-east-2.json



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
